### PR TITLE
(#153) Ignore whitespaces in split function

### DIFF
--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -6,8 +6,11 @@ void split(std::vector <std::string> &out, const std::string &str, char delim) {
     std::stringstream ss(str);
     std::string tmp;
     out.clear();
-    while(std::getline(ss, tmp, delim))
-        out.push_back(tmp);
+    while(std::getline(ss, tmp, delim)) {
+        if (tmp.size() != 0) {
+            out.push_back(tmp);
+        }
+    }
 }
 
 void replace_all(std::string &str, const std::string_view old_value, const std::string_view new_value) {


### PR DESCRIPTION
close #153 