### PR TITLE
(#302) Fix memory leak in YAMLParser::get_next_event()

### DIFF
--- a/src/yaml_parser.cpp
+++ b/src/yaml_parser.cpp
@@ -38,7 +38,9 @@ YAMLParser::YAMLEvent YAMLParser::get_next_event() {
                     std::to_string(parser.problem_mark.line) + ":" +
                     std::to_string(parser.problem_mark.column) + " " +
                     parser.problem);
-    return YAMLParser::YAMLEvent(event);
+    YAMLParser::YAMLEvent next_event(event);
+    yaml_event_delete(&event);
+    return next_event;
 }
 
 bool YAMLParser::Mapping::has_key(const std::string_view name) const {


### PR DESCRIPTION
close #302 
```
==798== 
==798== HEAP SUMMARY:
==798==     in use at exit: 81,901 bytes in 784 blocks
==798==   total heap usage: 12,548 allocs, 11,764 frees, 1,969,706 bytes allocated
==798== 
==798== LEAK SUMMARY:
==798==    definitely lost: 0 bytes in 0 blocks
==798==    indirectly lost: 0 bytes in 0 blocks
==798==      possibly lost: 0 bytes in 0 blocks
==798==    still reachable: 81,901 bytes in 784 blocks
==798==         suppressed: 0 bytes in 0 blocks
==798== Reachable blocks (those to which a pointer was found) are not shown.
==798== To see them, rerun with: --leak-check=full --show-leak-kinds=all
==798== 
==798== For lists of detected and suppressed errors, rerun with: -s
==798== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```